### PR TITLE
Support a fallback theme mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ preferred colors. This will be determined when the plugin first starts up and ne
 query the preferred theme.
 
 If `theme_mode` fails to detect an appropriate theme, you can use `theme_mode_fallback`
-to provide a value that should be used instead. This is only relevant when
-`theme_mode == "system"`. `theme_mode_fallback` should be either `dark` or `light`.
+to specify a value that should be used instead. This is only relevant when
+`theme_mode` is set to `"system"`. `theme_mode_fallback` should be either `"dark"` or
+`"light"`.
 
 **NOTE:** If you want to dynamically change the colorscheme's background,
 *you may not need this plugin.* Neovim should set your `background` option based on the

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ When the `theme_mode` is `system`, this plugin will do its best to guess your sy
 preferred colors. This will be determined when the plugin first starts up and needs to
 query the preferred theme.
 
+If `theme_mode` fails to detect an appropriate theme, you can use `theme_mode_fallback`
+to provide a value that should be used instead. This is only relevant when
+`theme_mode == "system"`. `theme_mode_fallback` should be either `dark` or `light`.
+
 **NOTE:** If you want to dynamically change the colorscheme's background,
 *you may not need this plugin.* Neovim should set your `background` option based on the
 background of your terminal. This is different from querying the system theme, but this
@@ -57,6 +61,7 @@ require("colorscheme").setup({
   preferred_dark_colorscheme = "habamax",
   preferred_light_colorscheme = "default",
   theme_mode = "system",
+  theme_mode_fallback = "dark",
 })
 ```
 

--- a/lua/colorscheme/init.lua
+++ b/lua/colorscheme/init.lua
@@ -163,7 +163,7 @@ function M.setup(opts)
   end
   if opts.theme_mode then
     theme_mode = opts.theme_mode
-    local theme = resolve_theme(theme_mode)
+    local theme = resolve_theme(theme_mode) or resolve_theme(opts.theme_mode_fallback) or "light"
     vim.o.background = theme.background
     vim.cmd.colorscheme(theme.colorscheme)
   end

--- a/lua/colorscheme/systemtheme/linux.lua
+++ b/lua/colorscheme/systemtheme/linux.lua
@@ -25,8 +25,7 @@ local function get_system_theme()
   if desktop_environment == "gnome" then
     return get_gnome_system_theme()
   end
-  -- NOTE Assume "light" if unknown since most systems are light by default.
-  return "light"
+  return nil
 end
 
 return get_system_theme()

--- a/lua/colorscheme/systemtheme/unknown.lua
+++ b/lua/colorscheme/systemtheme/unknown.lua
@@ -1,1 +1,1 @@
-return "light"
+return nil

--- a/lua/colorscheme/systemtheme/windows.lua
+++ b/lua/colorscheme/systemtheme/windows.lua
@@ -2,7 +2,7 @@ local function get_system_theme()
   local system_root = os.getenv("SystemRoot") or ""
   -- NOTE If %SystemRoot% isn't set for whatever reason, escape
   if system_root == "" then
-    return "light"
+    return nil
   end
   local reg_path = table.concat(
     {
@@ -33,7 +33,7 @@ local function get_system_theme()
   local apps_use_light_theme = handle:read("*a"):match("0x(%x+)")
   handle:close()
   if not apps_use_light_theme then
-    return "light"
+    return nil
   end
   if tonumber(apps_use_light_theme, 16) == 0 then
     return "dark"


### PR DESCRIPTION
Useful when the theme mode is set to `"system"`, but the system theme
mode can't be detected.
